### PR TITLE
Always close() writer when destructor is called

### DIFF
--- a/minijson_writer.hpp
+++ b/minijson_writer.hpp
@@ -553,6 +553,11 @@ protected:
     {
     }
 
+    ~writer()
+    {
+        close();
+    }
+
 public:
 
     std::ostream& stream() const

--- a/minijson_writer_tests.cpp
+++ b/minijson_writer_tests.cpp
@@ -124,6 +124,18 @@ TEST(minijson_writer, nesting_simple)
     ASSERT_EQ("{\"nested\":{\"foo\":\"bar\"}}", stream.str());
 }
 
+TEST(minijson_writer, nesting_simple_autoclose)
+{
+    std::stringstream stream;
+    minijson::object_writer writer(stream);
+    {
+        minijson::object_writer nested_writer = writer.nested_object("nested");
+        nested_writer.write("foo", "bar");
+    }
+    writer.close();
+    ASSERT_EQ("{\"nested\":{\"foo\":\"bar\"}}", stream.str());
+}
+
 TEST(minijson_writer, nesting_complex)
 {
     std::stringstream stream;


### PR DESCRIPTION
When the user is finished with a `writer` object, the `close()` method must be called. This change adds a `~writer()` destructor which automatically calls the `close()` method if it has not already been called by the user. 