### PR TITLE
Suppress generation of assignment operator

### DIFF
--- a/minijson_writer.hpp
+++ b/minijson_writer.hpp
@@ -271,6 +271,9 @@ private:
     char m_buffer[Size];
     size_t m_offset;
 
+    buffered_writer(const buffered_writer &);
+    buffered_writer &operator=(const buffered_writer &);
+
 public:
 
     explicit buffered_writer(std::ostream& stream) :


### PR DESCRIPTION
When compiled with the MSVC compiler under the maximum warning level (/W4), the `buffered_writer` class causes compiler warning [C4512](https://msdn.microsoft.com/en-us/library/hsyx7kbz.aspx) when generating the assignment operator due to the presence of the reference class member. This change suppresses the automatic generation of the assignment operator.