### PR TITLE
Add build file for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+install:
+  # Ensure that we use a compiler that supports C++11.
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - perl -i -n -e 'print unless /^CXX=/' Makefile
+
+  # Download and build google test.
+  - wget https://github.com/google/googletest/archive/release-1.7.0.zip && unzip release-1.7.0.zip && (cd googletest-release-1.7.0 && cmake . && make)
+
+  # Set up build flags to point to local copy of google test.
+  - perl -i -p -e 's!$! -Igoogletest-release-1.7.0/include! if /^CXXFLAGS=/' Makefile
+  - perl -i -p -e 's!=!=-Lgoogletest-release-1.7.0 ! if /^LDFLAGS=/' Makefile
+
+  # Skip coverage test and report for Travis-CI build.
+  - perl -i -n -e 'print unless /LCOV_COMMAND|GENHTML_COMMAND/' Makefile
+
+# This section is required to get new enough compilers that actually support C++11.
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+      - clang
+
+script: make run
+
+sudo: false


### PR DESCRIPTION
Travis-CI provides a free continuous integration service for Github projects. The [Travis CI Getting Started](http://docs.travis-ci.com/user/getting-started/) page describes the steps necessary to set this up. The `.travis.yml` file in this pull request currently works, but may need modification in the future if the example `Makefile` changes. You can see the current results for my fork at https://travis-ci.org/ghewgill/minijson_writer.